### PR TITLE
testet on CentOS + correct float convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ It provides perfdata feedback as well.
 
 ### Currently tested OS/ZFS versions
 * Ubuntu 14.04 LTS, ZFS v5
+* CentOS 7, ZFS v5

--- a/check_zfs.py
+++ b/check_zfs.py
@@ -68,6 +68,7 @@ def CheckArgBounds( valueArr, minVal, maxVal ):
 
 def ConvertToGB( valueStr ):
     value = valueStr[:-1]
+    value = value.replace(',', '.')
     if valueStr.endswith('G'):
         return float(value)
     elif valueStr.endswith('T'):


### PR DESCRIPTION
Hi,
thank you for your good check.

I installed zfs on a CentOS 7 VM. It works very good.
I run into one issue. We should replace "," to "." for a good float conversion.

Greetings
Reamer
