### PR TITLE
Provide a SELinux type enforcement file for use with nrpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ It provides perfdata feedback as well.
 * Ubuntu 14.04 LTS, ZFS v5
 * Ubuntu 16.04 LTS, ZFS v5
 * CentOS 7, ZFS v5
+
+### SELinux ###
+
+On systems with SELinux in enforcing mode nrpe is not granted the 
+required permissions by SELinux, for that you can compile a policy
+module, then a policy package that can then be installed.
+
+A sample can be used as follows:
+* Build a policy module: checkmodule -M -m -o check_zfs_py.mod contrib/SELinux/check_zfs_py.te
+* Build a policy package: semodule_package -o check_zfs_py.pp -m check_zfs_py.mod
+* Load the policy package: semodule -i check_zfs_py.pp
+
+If you want to unload it: semodule -i check_zfs_py

--- a/contrib/SELinux/check_zfs_py.te
+++ b/contrib/SELinux/check_zfs_py.te
@@ -1,0 +1,14 @@
+
+module check_zfs_py 1.0.5;
+
+require {
+	type nrpe_t;
+	type device_t;
+	class chr_file { ioctl open read write };
+}
+
+#============= nrpe_t ==============
+allow nrpe_t device_t:chr_file { read write };
+
+#!!!! This avc is allowed in the current policy
+allow nrpe_t device_t:chr_file { ioctl open };


### PR DESCRIPTION
Hi Zach

I've had some trouble getting this check to work on CentOS 7.5 with nrpe and SELinux in enforcing mode. After several attempts with audit2allow I came up with a type enforcement file that can be compiled into a policy package granting the required permissions.

I'd like to share it upstream and spare others the sweat and time we had to invest as we have a CentOS/ZFS system where SELinux was mandated to stay enabled.

Looking forward to your feedback

-- Mathieu