### PR TITLE
Give "just enough permissions" sudo examples

### DIFF
--- a/check_zfs.py
+++ b/check_zfs.py
@@ -145,7 +145,7 @@ try:
     childProcess = subprocess.Popen(fullCommand, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 except OSError:
     stateNum = RaiseStateNum(3, stateNum)
-    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zfs"
+    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zfs list"
     exit(stateNum)
 
 zfsString = childProcess.communicate()[0]
@@ -153,7 +153,7 @@ zfsRetval = childProcess.returncode
 
 if zfsRetval is 1:
     stateNum = RaiseStateNum(3, stateNum)
-    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zfs"
+    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zfs list"
     exit(stateNum)
 
 zfsLines = zfsString.splitlines()
@@ -183,14 +183,14 @@ try:
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 except OSError:
     stateNum = RaiseStateNum(3, stateNum)
-    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zpool"
+    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zpool list *"
     exit(stateNum)
 zpoolString = childProcess.communicate()[0]
 zpoolRetval = childProcess.returncode
 
 if zpoolRetval is 1:
     stateNum = RaiseStateNum(3, stateNum)
-    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zpool"
+    print nagiosStatus[stateNum] + ": process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: /sbin/zpool list *"
     exit(stateNum)
 
 zpoolLines=zpoolString.splitlines()


### PR DESCRIPTION
We should tell the user how to give just enough privileges to the monitoring
system to do what it needs to check the zpools' state. If we grant sudo
NOPASSWD to i.e. zpool this grants a access to potentially dangerous commands
like zpool export or even zpool destroy.