### PR TITLE
Update SELinux type enforcement for EL 7.6

### DIFF
--- a/contrib/SELinux/check_zfs_py.te
+++ b/contrib/SELinux/check_zfs_py.te
@@ -1,14 +1,19 @@
 
-module check_zfs_py 1.0.5;
+module check_zfs_py 1.0.7;
 
 require {
 	type nrpe_t;
 	type device_t;
+	type systemd_logind_t;
+	type nagios_unconfined_plugin_t;
 	class chr_file { ioctl open read write };
+	class dbus send_msg;
 }
 
 #============= nrpe_t ==============
 allow nrpe_t device_t:chr_file { read write };
+
+allow systemd_logind_t nagios_unconfined_plugin_t:dbus send_msg;
 
 #!!!! This avc is allowed in the current policy
 allow nrpe_t device_t:chr_file { ioctl open };


### PR DESCRIPTION
This has been tested on EL 7.6 and ZFS on Linux (ZoL) 0.7.12 with
nrpe 3.2.1 from EPEL.

It seems that since the last batch of updates in the upstream the
check now needs some dbus access to work. This should grant them.