### PR TITLE
Improvements to sudo behavior and debugging, NCPA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,103 @@ commands:
 ```
 TODO
 ```
+## Sudo Issues
+
+The zfs command binaries that Check_ZFS_Linux uses to perform its checks are the following:
+
+```
+/sbin/zfs
+/sbin/zpool
+```
+
+They need to be run as root in order to work properly. Since Nagios / NCPA / NRPE all typically
+run as the user 'nagios', we need to give Nagios sudo access in order to run these binaries 
+correctly. If Check_ZFS_Linux has problems sudo'ing to root, you'll see errors along these lines:
+
+```
+UNKNOWN : process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: Context: Zpool command - retval. Original command: "['/usr/bin/sudo', '-n', '/sbin/zpool', 'list', 'rpool']", then run check script with --nosudo option.
+```
+
+When debugging these issues, it may prove useful to run them from the host being monitored directly.
+For example, here the check_zfs.py script succeeds when run as root:
+
+```
+root@hydrox:~/ncpa/plugins# whoami
+root
+root@hydrox:~/ncpa/plugins# ./check_zfs.py rpool
+OK: POOL: rpool, STATUS: ONLINE, SIZE: 928G, ALLOC: 209G, FREE: 719G, DEDUP: 1.00x, COMPRESS: 1.11x, FRAG: 5%, CAP: 22% | frag=5%;;; cap=22%;;; dedup=1.00 compress_ratio=1.11 size=928.0GB;;; alloc=209.0GB;;; free=719.0GB;;; health=0;1;3; 
+root@hydrox:~/ncpa/plugins# 
+```
+
+But when run as the 'nagios' user, it fails:
+
+```
+root@hydrox:~/ncpa/plugins# su nagios
+$ whoami
+nagios
+$  ./check_zfs.py rpool
+UNKNOWN : process must be run as root. Possible solution: add the following to your visudo: nagios ALL=NOPASSWD: Context: Zpool command - retval. Original command: "['/usr/bin/sudo', '-n', '/sbin/zpool', 'list', 'rpool']", then run check script with --nosudo option.
+$
+```
+
+So, how do you fix this?
+
+As the error suggests, try adding a line to the /etc/sudoers file for nagios. Best practice typically encourages you to use the visudo utility to do this editing. Here is what it might look like afterwards:
+
+```
+root@hydrox:/etc/sudoers.d# pwd
+/etc/sudoers.d
+root@hydrox:/etc/sudoers.d# ls -l
+total 9
+-r--r----- 1 root root 958 Feb  1 22:41 README
+-r--r----- 1 root root 696 Jul 11 18:09 zfs
+root@hydrox:/etc/sudoers.d# cat zfs
+nagios ALL=NOPASSWD: /sbin/zfs
+nagios ALL=NOPASSWD: /sbin/zpool
+```
+
+After you've given the nagios user access to run the zfs commands, try to run the check_zfs script again. Hopefully it now works, but if not, try using the '--nosudo' option.
+
+```
+root@hydrox:~/ncpa/plugins# su nagios
+$ whoami
+nagios
+$ ./check_zfs.py rpool --nosudo
+OK: POOL: rpool, STATUS: ONLINE, SIZE: 928G, ALLOC: 209G, FREE: 719G, DEDUP: 1.00x, COMPRESS: 1.11x, FRAG: 5%, CAP: 22% | frag=5%;;; cap=22%;;; dedup=1.00 compress_ratio=1.11 size=928.0GB;;; alloc=209.0GB;;; free=719.0GB;;; health=0;1;3; 
+$
+```
+
+## Sample NCPA Configuration Example:
+
+From commands.cfg on the Nagios host:
+```
+# 
+# NCPA driven remote-ZFS check
+# 
+define command {
+    #
+    # Arg1 = token (community string)
+    # Arg2 = ZFS pool name
+    #
+    command_name        check-zfs-on-remote-host
+    command_line        $USER1$/check_ncpa.py -H $HOSTADDRESS$ -t $ARG1$ -M 'plugins/check_zfs.py' -a "$ARG2$ --nosudo"
+}
+```
+
+From ncpa.cfg on the remote host being monitored:
+```
+#
+# Extensions for plugins
+# ----------------------
+...
+
+# Forcing move to python 3
+.py = /usr/bin/python3 $plugin_name $plugin_args
+```
+
+Place check_zfs.py into the NCPA plugin's directory (/root/ncpa/plugins for example)
+
+
 
 ### SELinux ###
 


### PR DESCRIPTION
When trying to get nagios_check_zfs_linux working, I had a number of issues revolving around sudo, and this is an attempt to improve some of them.

* --nosudo option that prevents the script from prefxing zfs commands with "sudo -n". This helps in some situations where the command will run fine when run as the nagios user, but will fail if the nagios user prefixed the same command with "sudo -n". 
* Better crashes when sudo issues encountered, so user has a better idea of what's going wrong. 
* Python 3 version checker. Not entirely successful, but a reasonable idea.
* Some Python 3 f-strings usage
* Fixing deprecation warnings for logging triggered by using Python3
* Documentation on how to run on a remote host using NCPA
* Documentation of both sudo issues and --nosudo commad flag.