### PR TITLE
added support for all ways to enable compression in zfs

### DIFF
--- a/check_zfs.py
+++ b/check_zfs.py
@@ -350,7 +350,7 @@ if compressName=='':
     stateNum = RaiseStateNum(3, stateNum)
     logging.warning("%s: Missing required field in zpool output: NAME", nagiosStatus[stateNum])
     exit(stateNum)
-if compressValue=='on':
+if compressValue and compressValue!='off':
     getCompressRatioCommand = GetArgsForZfsCommand([zfsCommand, 'get', 'compressratio', args.pool])
 
     try:


### PR DESCRIPTION
There's nearly 40 different values that enable compression (like "gzip", "lz4", and even specific compression levels like "zstd-fast-20", etc.) in openzfs and new values are being added from time to time. As zfs only allows to set valid values checking that the value exists and is not "off" should handle all cases.